### PR TITLE
add output the path of ckpt to fifo

### DIFF
--- a/include/checkpoint/directed_tbs.h
+++ b/include/checkpoint/directed_tbs.h
@@ -4,13 +4,14 @@
 #include <stdint.h>
 #include <stdbool.h>
 
+#define FILEPATH_BUF_SIZE 256
 #define MAX_HARTS 8
 
 typedef struct Qemu2Detail {
     bool cpt_ready;
     uint32_t cpt_id;
     uint64_t total_inst_count;
-    char checkpoint_path[256];
+    char checkpoint_path[FILEPATH_BUF_SIZE];
 } Qemu2Detail;
 
 typedef struct Detail2Qemu {

--- a/include/checkpoint/directed_tbs.h
+++ b/include/checkpoint/directed_tbs.h
@@ -1,3 +1,6 @@
+#ifndef DIRECTED_TBS_H
+#define DIRECTED_TBS_H
+
 #include <stdint.h>
 #include <stdbool.h>
 
@@ -7,6 +10,7 @@ typedef struct Qemu2Detail {
     bool cpt_ready;
     uint32_t cpt_id;
     uint64_t total_inst_count;
+    char checkpoint_path[256];
 } Qemu2Detail;
 
 typedef struct Detail2Qemu {
@@ -14,8 +18,9 @@ typedef struct Detail2Qemu {
     bool has_wfi[MAX_HARTS];
 } Detail2Qemu;
 
-
 typedef struct SyncControlInfo {
     Detail2Qemu u_arch_info;
     int info_vaild_periods;
 } SyncControlInfo;
+
+#endif

--- a/include/checkpoint/serializer_utils.h
+++ b/include/checkpoint/serializer_utils.h
@@ -2,6 +2,7 @@
 #define __SERIALIZER_UTILS__
 
 #include "checkpoint.pb.h"
+#include "directed_tbs.h"
 
 #define MAGIC_NUMBER 0xdeadbeef
 __attribute__((unused))
@@ -52,7 +53,7 @@ static single_core_rvgc_rvv_rvh_memlayout single_core_rvgcvh_default_memlayout =
 };
 
 
-void serialize_pmem(uint64_t inst_count, int using_gcpt_mmio, char* hardware_status_buffer, int buffer_size);
+void serialize_pmem(uint64_t inst_count, int using_gcpt_mmio, char* hardware_status_buffer, int buffer_size, Qemu2Detail *q2d_buf);
 void serializeRegs(int cpu_index, char *buffer, single_core_rvgc_rvv_rvh_memlayout *cpt_percpu_layout, uint64_t all_cpu_num, uint64_t arg_mtime);
 int cpt_header_encode(void *gcpt_mmio, checkpoint_header *cpt_header, single_core_rvgc_rvv_rvh_memlayout *cpt_memlayout);
 

--- a/target/riscv/multicore.c
+++ b/target/riscv/multicore.c
@@ -328,7 +328,7 @@ serialize(uint64_t memory_addr, int cpu_index, int cpus, uint64_t inst_count)
                                   cpt_header.cpt_offset + 1024 * 1024 * cpus);
     }
     serialize_pmem(inst_count, false, hardware_status_buffer,
-                   cpt_header.cpt_offset + 1024 * 1024 * cpus);
+                   cpt_header.cpt_offset + 1024 * 1024 * cpus, &q2d_buf);
 }
 
 static bool all_cpu_exit(uint64_t cpu_idx)

--- a/target/riscv/serializer.c
+++ b/target/riscv/serializer.c
@@ -100,7 +100,7 @@ static void serialize(uint64_t icount) {
     MachineState *ms = MACHINE(qdev_get_machine());
     NEMUState *ns = NEMU_MACHINE(ms);
     serializeRegs(0, ns->memory, &single_core_rvgcvh_default_memlayout, 1, 0);
-    serialize_pmem(icount, false, NULL, 0);
+    serialize_pmem(icount, false, NULL, 0, NULL);
 }
 
 static bool could_take_checkpoint(uint64_t icount){

--- a/target/riscv/serializer_utils.c
+++ b/target/riscv/serializer_utils.c
@@ -29,7 +29,6 @@ void serialize_pmem(uint64_t inst_count, int using_gcpt_mmio, char* hardware_sta
         gcpt_mmio_pmem_size += buffer_size;
     }
 
-#define FILEPATH_BUF_SIZE 256
     char filepath[FILEPATH_BUF_SIZE];
 
     //prepare path
@@ -42,7 +41,7 @@ void serialize_pmem(uint64_t inst_count, int using_gcpt_mmio, char* hardware_sta
     printf("prepare for generate checkpoint path %s pmem_size %ld\n",filepath,guest_pmem_size);
     assert(g_mkdir_with_parents(g_path_get_dirname(filepath), 0775)==0);
     if (q2d_buf != NULL)
-        memcpy(q2d_buf->checkpoint_path, filepath, sizeof(filepath));
+        memcpy(q2d_buf->checkpoint_path, filepath, sizeof(FILEPATH_BUF_SIZE));
 
 #ifdef USE_ZSTD_COMPRESS
     //zstd compress

--- a/target/riscv/serializer_utils.c
+++ b/target/riscv/serializer_utils.c
@@ -1,4 +1,5 @@
 #include "checkpoint/checkpoint.h"
+#include "checkpoint/directed_tbs.h"
 #include "hw/boards.h"
 #include "hw/riscv/nemu.h"
 #include "qemu/error-report.h"
@@ -9,7 +10,7 @@
 #include <zstd.h>
 
 #define USE_ZSTD_COMPRESS
-void serialize_pmem(uint64_t inst_count, int using_gcpt_mmio, char* hardware_status_buffer, int buffer_size)
+void serialize_pmem(uint64_t inst_count, int using_gcpt_mmio, char* hardware_status_buffer, int buffer_size, Qemu2Detail *q2d_buf)
 {
 
     MachineState *ms = MACHINE(qdev_get_machine());
@@ -40,6 +41,8 @@ void serialize_pmem(uint64_t inst_count, int using_gcpt_mmio, char* hardware_sta
 
     printf("prepare for generate checkpoint path %s pmem_size %ld\n",filepath,guest_pmem_size);
     assert(g_mkdir_with_parents(g_path_get_dirname(filepath), 0775)==0);
+    if (q2d_buf != NULL)
+        memcpy(q2d_buf->checkpoint_path, filepath, sizeof(filepath));
 
 #ifdef USE_ZSTD_COMPRESS
     //zstd compress


### PR DESCRIPTION
Export the checkpoint build path to the fifo, which is used to specify where emu loads the workload