### PR TITLE
riscv: Fix file extension mismatch in ZSTD checkpoint serialization

### DIFF
--- a/target/riscv/serializer_utils.c
+++ b/target/riscv/serializer_utils.c
@@ -63,6 +63,12 @@ void serialize_pmem(uint64_t inst_count, int using_gcpt_mmio, char* hardware_sta
     size_t const compress_size = ZSTD_compress(compress_buffer, compress_buffer_size, pmem_addr, guest_pmem_size, 1);
     assert(compress_size<=compress_buffer_size&&compress_size!=0);
 
+    // Fix file extension for zstd
+    char *ext = strrchr(filepath, '.');
+    if (ext && strcmp(ext, ".gz") == 0) {
+        strcpy(ext, ".zst");
+    }
+
     FILE *compress_file=fopen(filepath,"wb");
     size_t fw_size = fwrite(compress_buffer,1,compress_size,compress_file);
 


### PR DESCRIPTION
When using ZSTD compression, the filepath was incorrectly generated with .gz extension in every checkpointing mode. This patch corrects the extension to .zst before opening the file for writing, ensuring the file extension matches the actual compression format used.