### PR TITLE
fix(checkpoint): improve multi-hart checkpoint handling

### DIFF
--- a/include/checkpoint/serializer_utils.h
+++ b/include/checkpoint/serializer_utils.h
@@ -52,7 +52,8 @@ static single_core_rvgc_rvv_rvh_memlayout single_core_rvgcvh_default_memlayout =
 };
 
 
-void serialize_pmem(uint64_t inst_count, int using_gcpt_mmio, char* hardware_status_buffer, int buffer_size);
+bool serialize_pmem(uint64_t inst_count, int using_gcpt_mmio,
+                    char *hardware_status_buffer, int buffer_size);
 void serializeRegs(int cpu_index, char *buffer, single_core_rvgc_rvv_rvh_memlayout *cpt_percpu_layout, uint64_t all_cpu_num, uint64_t arg_mtime);
 int cpt_header_encode(void *gcpt_mmio, checkpoint_header *cpt_header, single_core_rvgc_rvv_rvh_memlayout *cpt_memlayout);
 

--- a/include/hw/riscv/nemu.h
+++ b/include/hw/riscv/nemu.h
@@ -92,6 +92,10 @@ typedef struct sync_info{
     bool *early_exit;  // such as wfi
     gint *checkpoint_end;
     gint *waiting;
+
+    /* Leader (last to arrive) takes the checkpoint and advances barrier_gen. */
+    gint barrier_arrive;
+    gint barrier_gen;
 }SyncInfo_t;
 
 enum CheckpointMode{

--- a/target/riscv/multicore.c
+++ b/target/riscv/multicore.c
@@ -27,7 +27,6 @@
 #include <sys/types.h>
 #include <unistd.h>
 
-static gint wait_id = 0;
 static uint64_t global_mtime = 0;
 gint simpoint_checkpoint_exit = 0;
 
@@ -35,7 +34,7 @@ gint simpoint_checkpoint_exit = 0;
 
 static void try_sync(NEMUState* ns, uint64_t icount, int cpu_idx,
                              bool exit_sync_period, bool *sync_end);
-__attribute_maybe_unused__ static void
+static bool __attribute_maybe_unused__
 serialize(uint64_t memory_addr, int cpu_idx, int cpus, uint64_t inst_count);
 
 __attribute_maybe_unused__ static inline void multicore_try_take_cpt(NEMUState* ns, uint64_t icount, int cpu_idx,
@@ -44,14 +43,16 @@ __attribute_maybe_unused__ static inline void multicore_try_take_cpt(NEMUState* 
 
 static inline void send_fifo(NEMUState *ns){
     ns->q2d_buf.cpt_ready = true;
-    write(ns->q2d_fifo, &ns->q2d_buf, sizeof(Qemu2Detail));
+    ssize_t ret = write(ns->q2d_fifo, &ns->q2d_buf, sizeof(Qemu2Detail));
+    (void)ret;
 }
 
 static inline void read_fifo(NEMUState *ns){
     ns->sync_control_info.info_vaild_periods -= 1;
     if (ns->sync_control_info.info_vaild_periods <= 0) {
-        read(ns->d2q_fifo, &ns->sync_control_info.u_arch_info,
+        ssize_t ret = read(ns->d2q_fifo, &ns->sync_control_info.u_arch_info,
              sizeof(Detail2Qemu));
+        (void)ret;
     }
 }
 
@@ -60,20 +61,11 @@ inline uint64_t simpoint_get_next_instructions(NEMUState *ns)
     GList *first_insns_item = g_list_first(ns->simpoint_info.cpt_instructions);
     if (first_insns_item == NULL) {
         set_simpoint_checkpoint_exit();
-        return LONG_LONG_MAX;
-    } else {
-        if (first_insns_item->data == 0) {
-            ns->simpoint_info.cpt_instructions = g_list_remove(
-                ns->simpoint_info.cpt_instructions,
-                g_list_first(ns->simpoint_info.cpt_instructions)->data);
-            ns->path_manager.checkpoint_path_list = g_list_remove(
-                ns->path_manager.checkpoint_path_list,
-                g_list_first(ns->path_manager.checkpoint_path_list)->data);
-            return LONG_LONG_MAX;
-        }
-        return GPOINTER_TO_UINT(first_insns_item->data) *
-               ns->nemu_args.cpt_interval;
+        return UINT64_MAX;
     }
+
+    return GPOINTER_TO_UINT(first_insns_item->data) *
+           ns->nemu_args.cpt_interval;
 }
 
 MODE_DEF_HELPER(simpoint,
@@ -192,9 +184,6 @@ static void single_try_set_mie(void *env, NEMUState *ns)
     info_report("Notify: disable timmer interrupr");
 }
 
-static void no_try_set_mie(void *env, NEMUState *ns)
-{
-}
 #define NO_PRINT
 
 void set_simpoint_checkpoint_exit(void){
@@ -206,7 +195,7 @@ __attribute__((unused)) static void set_global_mtime(void)
     cpu_physical_memory_read(CLINT_MMIO + CLINT_MTIME, &global_mtime, 8);
 }
 
-__attribute_maybe_unused__ static void
+static bool __attribute_maybe_unused__
 serialize(uint64_t memory_addr, int cpu_idx, int cpus, uint64_t inst_count)
 {
     MachineState *ms = MACHINE(qdev_get_machine());
@@ -241,8 +230,8 @@ serialize(uint64_t memory_addr, int cpu_idx, int cpus, uint64_t inst_count)
         cpu_physical_memory_write(memory_addr, hardware_status_buffer,
                                   cpt_header.cpt_offset + 1024 * 1024 * cpus);
     }
-    serialize_pmem(inst_count, false, hardware_status_buffer,
-                   cpt_header.cpt_offset + 1024 * 1024 * cpus);
+    return serialize_pmem(inst_count, false, hardware_status_buffer,
+                          cpt_header.cpt_offset + 1024 * 1024 * cpus);
 }
 
 static inline int sync_multicore(NEMUState *ns, uint64_t icount, int cpu_idx, int early_exit){
@@ -266,28 +255,22 @@ static void try_sync(NEMUState* ns, uint64_t icount, int cpu_idx,
                              bool exit_sync_period, bool *sync_end)
 {
     if (sync_multicore(ns, icount, cpu_idx, exit_sync_period) == WAIT) {
-        int tmp_wait_id = g_atomic_int_add(&wait_id, 1);
-        tmp_wait_id += 1;
-        if (tmp_wait_id != ns->sync_info.online_cpus) {
-            g_atomic_int_set(&ns->sync_info.waiting[cpu_idx], 1);
-//            info_report("cpu %d goto wait online state %d, wait id %d instructions %ld", cpu_idx, ns->sync_info.online_cpus, tmp_wait_id, icount - ns->sync_info.kernel_insns[cpu_idx]);
-            if (tmp_wait_id == 1) {
-                cpu_disable_ticks();
-                set_global_mtime();
+        /* A generation prevents arrivals leaking into the next barrier. */
+        int my_gen = g_atomic_int_get(&ns->sync_info.barrier_gen);
+        int arrived = g_atomic_int_add(&ns->sync_info.barrier_arrive, 1) + 1;
+        bool is_leader = (arrived == ns->sync_info.cpus);
+        g_assert(arrived <= ns->sync_info.cpus);
+        if (arrived == 1) {
+            /* The first arrival freezes global time. */
+            cpu_disable_ticks();
+            set_global_mtime();
+        }
+        if (is_leader) {
+            *sync_end = true;
+        } else {
+            while (g_atomic_int_get(&ns->sync_info.barrier_gen) == my_gen) {
+                cpu_relax();
             }
-
-            while (g_atomic_int_get(&ns->sync_info.checkpoint_end[cpu_idx]) == 0) {}
-            g_atomic_int_set(&ns->sync_info.checkpoint_end[cpu_idx], 0);
-
-            g_atomic_int_set(&ns->sync_info.waiting[cpu_idx], 0);
-        }else{
-//            info_report("cpu %d goto sync end, cpu_online %d, wait id %d instruction count %ld", cpu_idx, ns->sync_info.online_cpus, tmp_wait_id, icount - ns->sync_info.kernel_insns[cpu_idx]);
-            for (int i = 0; i < ns->sync_info.cpus; i++) {
-                if (i != cpu_idx) {
-                    while (g_atomic_int_get(&ns->sync_info.waiting[i]) != 1) {}
-                }
-            }
-            *sync_end = 1;
         }
     }
 }
@@ -303,31 +286,31 @@ void check_exit(uint64_t icount) {
 __attribute_maybe_unused__ static inline void multicore_try_take_cpt(NEMUState* ns, uint64_t icount, int cpu_idx,
                              bool exit_sync_period){
     bool sync_end = false;
-    static uint64_t wait_times = 0;
+    static aligned_uint64_t wait_times;
+
     try_sync(ns, icount, cpu_idx, exit_sync_period, &sync_end);
 
     if (sync_end) {
-        g_atomic_pointer_add(&wait_times, 1);
+        qatomic_fetch_add(&wait_times, 1);
         ns->cpt_func.update_sync_limit_instructions(ns);
 
         if ((icount - ns->sync_info.kernel_insns[cpu_idx]) >= ns->cpt_func.get_cpt_limit_instructions(ns)) {
 
-            info_report("cpu %d get cpt limit wait times %ld", cpu_idx, g_atomic_pointer_get(&wait_times));
-            g_atomic_pointer_set(&wait_times, 0);
+            info_report("cpu %d get cpt limit wait times %ld", cpu_idx,
+                        qatomic_read_u64(&wait_times));
+            qatomic_set_u64(&wait_times, 0);
 
-            serialize(0x80300000, cpu_idx, ns->sync_info.cpus, icount);
-            // update checkpoint limit instructions
-            ns->cpt_func.update_cpt_limit_instructions(ns, icount);
-            ns->cpt_func.after_take_cpt(ns, cpu_idx);
-        }
-
-        g_atomic_int_set(&wait_id, 0);
-
-        for (int i = 0; i < ns->sync_info.cpus; i++) {
-            if (g_atomic_int_get(&ns->sync_info.waiting[i]) == 1) {
-                g_atomic_int_set(&ns->sync_info.checkpoint_end[i], 1);
+            if (serialize(0x80300000, cpu_idx, ns->sync_info.cpus,
+                          icount)) {
+                /* Consume the SimPoint only after its checkpoint is written. */
+                ns->cpt_func.update_cpt_limit_instructions(ns, icount);
+                ns->cpt_func.after_take_cpt(ns, cpu_idx);
             }
         }
+
+        /* Reset arrivals before releasing peers into the next generation. */
+        g_atomic_int_set(&ns->sync_info.barrier_arrive, 0);
+        g_atomic_int_add(&ns->sync_info.barrier_gen, 1);
 
         cpu_enable_ticks();
     }
@@ -344,6 +327,9 @@ static void sync_init(NEMUState *ns, gint cpus){
     if(ns->nemu_args.checkpoint != NULL){
         // if checkpoint mode, default online 2 cpud
         ns->sync_info.online_cpus = cpus;
+        for (int i = 0; i < cpus; i++) {
+            ns->sync_info.online[i] = 1;
+        }
     }else{
         // if not, online cpus will add by before_worklod
         ns->sync_info.online_cpus = 0;
@@ -363,6 +349,9 @@ static void sync_init(NEMUState *ns, gint cpus){
     ns->sync_info.checkpoint_end = g_malloc0(cpus * sizeof(bool));
     // check sync status
     ns->sync_info.waiting = g_malloc0(cpus * sizeof(gint));
+
+    ns->sync_info.barrier_arrive = 0;
+    ns->sync_info.barrier_gen = 0;
 }
 
 NEMUState *local_nemu_state;
@@ -412,7 +401,7 @@ void multicore_checkpoint_init(MachineState *machine)
         ns->cpt_func.try_take_cpt = single_core_try_take_cpt;
         ns->cpt_func.try_set_mie = single_try_set_mie;
     }else{
-        ns->cpt_func.try_set_mie = no_try_set_mie;
+        ns->cpt_func.try_set_mie = single_try_set_mie;
     }
 }
 

--- a/target/riscv/op_helper.c
+++ b/target/riscv/op_helper.c
@@ -48,10 +48,12 @@ void helper_nemu_trap(CPURISCVState *env, target_ulong a0) {
         ns->cpt_func.try_set_mie(env ,ns);
     } else if (a0 == NOTIFY_PROFILER) {
         // workload loaded
-        g_atomic_int_set(&ns->sync_info.online[cs->cpu_index], 1);
-        g_atomic_int_add(&ns->sync_info.online_cpus, 1);
-
-        g_atomic_pointer_set(&ns->sync_info.kernel_insns[cs->cpu_index], env->profiling_insns);
+        if (g_atomic_int_get(&ns->sync_info.online[cs->cpu_index]) == 0) {
+            qatomic_set_i64(&ns->sync_info.kernel_insns[cs->cpu_index],
+                            env->profiling_insns);
+            g_atomic_int_set(&ns->sync_info.online[cs->cpu_index], 1);
+            g_atomic_int_inc(&ns->sync_info.online_cpus);
+        }
 
         printf("Notify cpu index %d nemu_trap get insns %ld get workload start profiling\n", cs->cpu_index,
         env->profiling_insns);
@@ -63,8 +65,10 @@ void helper_nemu_trap(CPURISCVState *env, target_ulong a0) {
 
         ns->cpt_func.try_take_cpt(ns, env->profiling_insns, cs->cpu_index, true);
 
-        g_atomic_int_set(&ns->sync_info.online[cs->cpu_index], 0);
-        g_atomic_int_add(&ns->sync_info.online_cpus, -1);
+        if (g_atomic_int_compare_and_exchange(
+                &ns->sync_info.online[cs->cpu_index], 1, 0)) {
+            g_atomic_int_add(&ns->sync_info.online_cpus, -1);
+        }
 
 
     } else if(a0 == GOOD_TRAP){

--- a/target/riscv/serializer.c
+++ b/target/riscv/serializer.c
@@ -13,9 +13,6 @@
 
 static bool instrsCouldTakeCpt(NEMUState *ns, int64_t icount) {
     uint64_t limit_instructions = simpoint_get_next_instructions(ns);
-    if (limit_instructions==0) {
-        return false;
-    }
 //    limit_instructions += 100000;
 
     switch (ns->nemu_args.checkpoint_mode) {
@@ -42,9 +39,10 @@ static bool instrsCouldTakeCpt(NEMUState *ns, int64_t icount) {
     return false;
 }
 
-static void serialize(NEMUState *ns, uint64_t icount) {
+static bool serialize(NEMUState *ns, uint64_t icount)
+{
     serializeRegs(0, ns->memory, &single_core_rvgcvh_default_memlayout, 1, 0);
-    serialize_pmem(icount, false, NULL, 0);
+    return serialize_pmem(icount, false, NULL, 0);
 }
 
 static bool could_take_checkpoint(NEMUState *ns, uint64_t icount){
@@ -89,8 +87,9 @@ static void update_cpt_limit_instructions(NEMUState *ns, uint64_t icount){
 void single_core_try_take_cpt(NEMUState* ns, uint64_t icount, int cpu_idx, bool exit_sync_period) {
     uint64_t workload_exec_insns = icount - ns->sync_info.kernel_insns[0];
     if (could_take_checkpoint(ns, workload_exec_insns)) {
-        serialize(ns, workload_exec_insns);
-        update_cpt_limit_instructions(ns, workload_exec_insns);
+        if (serialize(ns, workload_exec_insns)) {
+            update_cpt_limit_instructions(ns, workload_exec_insns);
+        }
     }
 }
 #endif

--- a/target/riscv/serializer_utils.c
+++ b/target/riscv/serializer_utils.c
@@ -14,7 +14,8 @@
 
 
 
-void serialize_pmem(uint64_t inst_count, int using_gcpt_mmio, char* hardware_status_buffer, int buffer_size)
+bool serialize_pmem(uint64_t inst_count, int using_gcpt_mmio,
+                    char *hardware_status_buffer, int buffer_size)
 {
 
     MachineState *ms = MACHINE(qdev_get_machine());
@@ -38,13 +39,32 @@ void serialize_pmem(uint64_t inst_count, int using_gcpt_mmio, char* hardware_sta
 
     //prepare path
     if (ns->nemu_args.checkpoint_mode == SimpointCheckpointing) {
-        strcpy(filepath,((GString*)(g_list_first(ns->path_manager.checkpoint_path_list)->data))->str);
+        GList *path_item = g_list_first(ns->path_manager.checkpoint_path_list);
+        if (path_item == NULL ||
+            g_strlcpy(filepath, ((GString *)path_item->data)->str,
+                      sizeof(filepath)) >= sizeof(filepath)) {
+            error_report("invalid or oversized SimPoint checkpoint path");
+            return false;
+        }
         info_report("prepare for generate checkpoint path %s inst_count %ld pmem_size %ld", filepath, inst_count, guest_pmem_size);
     }else if(ns->nemu_args.checkpoint_mode==UniformCheckpointing || ns->nemu_args.checkpoint_mode == SyncUniformCheckpoint){
-        sprintf(filepath, "%s/%ld/_%ld_.gz", ns->path_manager.uniform_path->str, inst_count, inst_count);
+        if (snprintf(filepath, sizeof(filepath), "%s/%ld/_%ld_.gz",
+                     ns->path_manager.uniform_path->str, inst_count,
+                     inst_count) >= sizeof(filepath)) {
+            error_report("uniform checkpoint path is too long");
+            return false;
+        }
         info_report("prepare for generate checkpoint path %s base_path %s inst_count %ld pmem_size %ld", filepath, ns->path_manager.uniform_path->str, inst_count, guest_pmem_size);
+    } else {
+        error_report("unsupported checkpoint mode");
+        return false;
     }
-    assert(g_mkdir_with_parents(g_path_get_dirname(filepath), 0775)==0);
+    g_autofree char *checkpoint_dir = g_path_get_dirname(filepath);
+    if (g_mkdir_with_parents(checkpoint_dir, 0775) != 0) {
+        error_report("failed to create checkpoint directory %s: %s",
+                     checkpoint_dir, strerror(errno));
+        return false;
+    }
 
 #ifdef USE_ZSTD_COMPRESS
     //zstd compress
@@ -60,20 +80,37 @@ void serialize_pmem(uint64_t inst_count, int using_gcpt_mmio, char* hardware_sta
         fprintf(stdout, "compress gcpt success, compress size %ld", gcpt_compress_size);
     }
 
-    size_t const compress_size = ZSTD_compress(compress_buffer, compress_buffer_size, pmem_addr, guest_pmem_size, 1);
-    assert(compress_size<=compress_buffer_size&&compress_size!=0);
+    size_t const compress_size = ZSTD_compress(
+        compress_buffer, compress_buffer_size, pmem_addr, guest_pmem_size, 1);
+    if (ZSTD_isError(compress_size)) {
+        error_report("failed to compress checkpoint: %s",
+                     ZSTD_getErrorName(compress_size));
+        free(compress_buffer);
+        return false;
+    }
 
     FILE *compress_file=fopen(filepath,"wb");
+    if (compress_file == NULL) {
+        error_report("failed to open checkpoint %s: %s", filepath,
+                     strerror(errno));
+        free(compress_buffer);
+        return false;
+    }
     size_t fw_size = fwrite(compress_buffer,1,compress_size,compress_file);
+    bool write_ok = fw_size == compress_size;
 
-    if (fw_size != (size_t)compress_size) {
-        fprintf(stderr, "fwrite: %s : %s \n", filepath, strerror(errno));
+    if (!write_ok) {
+        fprintf(stderr, "fwrite: %s: %s\n", filepath, strerror(errno));
     }
     if (fclose(compress_file)) {
-        fprintf(stderr, "fclose: %s : %s \n", filepath, strerror(errno));
+        fprintf(stderr, "fclose: %s: %s\n", filepath, strerror(errno));
+        write_ok = false;
     }
 
     free(compress_buffer);
+    if (!write_ok) {
+        return false;
+    }
     info_report("serialize pmem finish\n");
 
 #endif
@@ -81,11 +118,12 @@ void serialize_pmem(uint64_t inst_count, int using_gcpt_mmio, char* hardware_sta
 #ifdef USE_ZLIB_COMPRESS
     //zlib compress
     gzFile compressed_mem=NULL;
+    bool zlib_write_ok = true;
     compressed_mem=gzopen(filepath,"wb");
 
     if (!compressed_mem) {
         error_printf("filename %s can't open", filepath);
-        return;
+        return false;
     }
 
     uint64_t write_size;
@@ -95,17 +133,24 @@ void serialize_pmem(uint64_t inst_count, int using_gcpt_mmio, char* hardware_sta
         printf("wirte in index %d\n",i);
         if (write_size != seg_size) {
             error_printf("qmp_gzpmemsave write error size %ld index %d\n",write_size,i);
+            zlib_write_ok = false;
             goto exit;
         }
     }
     info_report("success write into checkpoint file: %s",filepath);
 exit:
-    gzclose(compressed_mem);
+    if (gzclose(compressed_mem) != Z_OK) {
+        zlib_write_ok = false;
+    }
+    if (!zlib_write_ok) {
+        return false;
+    }
 #endif
     //    useless for now
     //    uint64_t mtime;
     //    cpu_physical_memory_read(MTIME_CMP_CPT_ADDR, &mtime, 8);
     //    cpu_physical_memory_write(CLINT_MMIO+CLINT_MTIME, &mtime, 8);
+    return true;
 }
 
 


### PR DESCRIPTION
This PR replaces the multi-hart checkpoint wait protocol with a generation-based barrier and propagates checkpoint serialization failures to the callers.

Changes:
- Replace the shared wait counter and per-hart wakeup flags with a generation barrier.
- Freeze global time at the first barrier arrival and release peers only after the leader completes checkpoint processing.
- Apply the guest time-interrupt disable trap to each participating hart.
- Avoid double-counting repeated workload-start notifications.
- Make checkpoint serialization return success/failure.
- Validate checkpoint paths, create output directories, and report compression and file-write failures without consuming the checkpoint point.