### PR TITLE
feat(plugins/profilingv2): start profiling at explicit marker

### DIFF
--- a/contrib/plugins/profilingv2.c
+++ b/contrib/plugins/profilingv2.c
@@ -12,6 +12,16 @@ QEMU_PLUGIN_EXPORT int qemu_plugin_version = QEMU_PLUGIN_VERSION;
 
 #define NO_LOG
 
+#define NEMU_TRAP_INSN 0x0000006b
+#define DISABLE_TIME_INTR 0x100
+#define NOTIFY_PROFILER 0x101
+
+typedef enum ProfilingState {
+    PROFILING_WAITING,
+    PROFILING_STARTING,
+    PROFILING_ACTIVE,
+} ProfilingState;
+
 typedef struct {
     uint64_t first;
     uint64_t second;
@@ -29,10 +39,10 @@ typedef struct ProfilingInfo {
 } ProfilingInfo_t;
 
 typedef struct ProfilingControl {
-    bool start_profiling;
+    ProfilingState state;
+    bool marker_error_reported;
     uint64_t unique_trans_id;
     uint64_t unique_exec_id;
-    uint64_t execute_instr_counts;
     uint64_t profiling_instr_counts;
     uint64_t per_bb_vector_instr_count;
     GMutex bbv_lock;
@@ -77,10 +87,12 @@ typedef struct BasicBlockExecCount {
     uint64_t exec_id;
 } BasicBlockExecCount_t;
 
-static const qemu_info_t* qemu_info;
+static qemu_plugin_id_t plugin_id;
 static ProfilingInfo_t profiling_info;
 static ProfilingControl_t profiling_control;
 static struct qemu_plugin_scoreboard *score_board;
+static struct qemu_plugin_register **a0_registers;
+static size_t a0_register_count;
 
 /* descriptors for accessing the above scoreboard */
 static qemu_plugin_u64 current_block_end_pc;
@@ -92,6 +104,14 @@ static qemu_plugin_u64 current_tb_execd_insn_cnt;
 static qemu_plugin_u64 current_tb_total_cnt;
 static qemu_plugin_u64 middle_exit_flag;
 static qemu_plugin_u64 current_bbv_entry;
+
+static void vcpu_tb_trans(struct qemu_plugin_tb *tb, void *userdata);
+static void profiling_exit(void *userdata);
+static void try_output_to_bb_file(void);
+static void output_bbv_vector(void);
+static void rollback_instr_counter(uint64_t unexecuted_insns,
+                                   BasicBlockExecCount_t *original_bb_cnt,
+                                   uint64_t first_pc, uint64_t second_pc);
 
 static guint hash_pair(gconstpointer key) {
     const UInt64Pair *p = (const UInt64Pair *)key;
@@ -121,18 +141,17 @@ static void init_bbv_file(const GString *target_dirname,
     assert(profiling_control.bbv_file);
 }
 
-static void init_profiling_control(const GString *target_dirname,
-                                     const GString *workload_filename) {
-    profiling_control.start_profiling = false;
+static void init_profiling_control(void)
+{
+    profiling_control.state = PROFILING_WAITING;
+    profiling_control.marker_error_reported = false;
     profiling_control.unique_trans_id = 0;
     /* SimPoint dimensions are one-based; dimension zero is invalid. */
     profiling_control.unique_exec_id = 1;
-    profiling_control.execute_instr_counts = 0;
     profiling_control.profiling_instr_counts = 0;
     g_mutex_init(&profiling_control.bbv_lock);
     profiling_control.bbv =
         g_hash_table_new_full(hash_pair, compare_pair, g_free, g_free);
-    init_bbv_file(target_dirname, workload_filename);
 }
 
 static void init_score_board(void) {
@@ -193,65 +212,121 @@ static inline void score_board_record_inject_before_tb_exec(
         0);
 }
 
-static void clean_exec_count(gpointer key, gpointer value, gpointer user_data) {
-    g_assert(value);
-    BasicBlockExecCount_t *ec = (BasicBlockExecCount_t *)value;
-    ec->per_vector_exec_instr_count = 0;
-}
-
-static void nemu_trap_check(unsigned int vcpu_index, void *userdata) {
-    static int profiling_exit = 0;
-
-    if (profiling_exit == 1) {
+static void enable_profiling(void *userdata)
+{
+    if (profiling_control.state != PROFILING_STARTING) {
         return;
     }
+
+    init_bbv_file(profiling_info.path.target_path,
+                  profiling_info.path.workload_path);
+    init_score_board();
+    profiling_control.state = PROFILING_ACTIVE;
+
+    qemu_plugin_register_vcpu_tb_trans_cb(plugin_id, vcpu_tb_trans, NULL);
+    qemu_plugin_register_atexit_cb(plugin_id, profiling_exit, NULL);
+
+    printf("PLUGIN: workload loaded, profiling enabled\n");
+}
+
+static void vcpu_init(unsigned int vcpu_index, void *userdata)
+{
+    g_autoptr(GArray) registers = qemu_plugin_get_registers();
+
+    if (vcpu_index >= a0_register_count) {
+        fprintf(stderr,
+                "profilingv2: vCPU index %u exceeds configured maximum\n",
+                vcpu_index);
+        return;
+    }
+
+    for (size_t i = 0; i < registers->len; i++) {
+        qemu_plugin_reg_descriptor *reg = &g_array_index(
+            registers, qemu_plugin_reg_descriptor, i);
+
+        if (g_strcmp0(reg->name, "a0") == 0) {
+            a0_registers[vcpu_index] = reg->handle;
+            return;
+        }
+    }
+
+    fprintf(stderr, "profilingv2: RISC-V register a0 is unavailable on "
+            "vCPU %u\n", vcpu_index);
+}
+
+static bool read_marker_code(unsigned int vcpu_index, uint64_t *marker_code)
+{
+    g_autoptr(GByteArray) value = g_byte_array_new();
+    struct qemu_plugin_register *reg;
+
+    if (vcpu_index >= a0_register_count || !a0_registers[vcpu_index]) {
+        return false;
+    }
+
+    reg = a0_registers[vcpu_index];
+    if (!qemu_plugin_read_register(reg, value) ||
+        value->len == 0 || value->len > sizeof(*marker_code)) {
+        return false;
+    }
+
+    *marker_code = 0;
+    for (size_t i = 0; i < value->len; i++) {
+        *marker_code |= (uint64_t)value->data[i] << (i * 8);
+    }
+    return true;
+}
+
+static void nemu_trap_check(unsigned int vcpu_index, void *userdata)
+{
+    uint64_t marker_code;
 
     if (vcpu_index != 0) {
         return;
     }
 
-    static int nemu_trap_count = 0;
-
-    printf("From plugin, all exec instrs %ld, all profiling instrs %ld\n", profiling_control.execute_instr_counts, profiling_control.profiling_instr_counts);
-    if (profiling_control.start_profiling == true) {
-        // prepare exit
-        printf("PLUGIN: After profiling GET NEMU_TRAP\n");
-        printf("SimPoint profiling exit, total guest instructions = %ld, total profiling instrs = %ld\n",
-               profiling_control.execute_instr_counts, profiling_control.profiling_instr_counts);
-        profiling_exit = 1;
+    if (!read_marker_code(vcpu_index, &marker_code)) {
+        if (!profiling_control.marker_error_reported) {
+            fprintf(stderr, "profilingv2: cannot read RISC-V a0 marker code\n");
+            profiling_control.marker_error_reported = true;
+        }
         return;
     }
-    // disable timer
-    nemu_trap_count += 1;
-    // start profiling
-    if (nemu_trap_count == 2) {
-        // The first TB that starts profiling triggers a nemu_trap in the
-        // middle, and the number of instructions after the nemu_trap is
-        // not included in profiling, so it needs to be corrected
-        profiling_control.start_profiling = true;
-        g_mutex_lock(&profiling_control.bbv_lock);
-        g_hash_table_foreach(profiling_control.bbv, clean_exec_count, NULL);
-        g_mutex_unlock(&profiling_control.bbv_lock);
-        profiling_control.profiling_instr_counts = 0;
-        profiling_control.per_bb_vector_instr_count = 0;
-        printf("PLUGIN: worklaod loaded........................\n");
+
+    switch (marker_code) {
+    case DISABLE_TIME_INTR:
+        return;
+    case NOTIFY_PROFILER:
+        if (profiling_control.state != PROFILING_WAITING) {
+            fprintf(stderr, "profilingv2: ignoring profile BEGIN in state %d\n",
+                    profiling_control.state);
+            return;
+        }
+        profiling_control.state = PROFILING_STARTING;
+        qemu_plugin_reset(plugin_id, enable_profiling, NULL);
+        return;
+    default:
+        return;
     }
-    return;
 }
 
 static inline void try_inject_nemu_trap_check(struct qemu_plugin_tb *tb, uint64_t tb_instrs) {
-    uint32_t data;
     for (size_t i = 0; i < tb_instrs; i++) {
         struct qemu_plugin_insn *insn = qemu_plugin_tb_get_insn(tb, i);
+        uint32_t data = 0;
 
         uint32_t size = qemu_plugin_insn_data(insn, &data, sizeof(uint32_t));
         assert(size == sizeof(uint32_t) || size == sizeof(uint16_t));
-        if (data == 0x6b) {
+        if (size == sizeof(uint32_t) && data == NEMU_TRAP_INSN) {
             qemu_plugin_register_vcpu_insn_exec_cb(insn, nemu_trap_check,
-                                                   QEMU_PLUGIN_CB_NO_REGS,
+                                                   QEMU_PLUGIN_CB_R_REGS,
                                                    GUINT_TO_POINTER(data));
         }
     }
+}
+
+static void waiting_vcpu_tb_trans(struct qemu_plugin_tb *tb, void *userdata)
+{
+    try_inject_nemu_trap_check(tb, qemu_plugin_tb_n_insns(tb));
 }
 
 static inline void score_board_record_inject_before_insn_exec(struct qemu_plugin_tb *tb, uint64_t tb_instrs) {
@@ -294,19 +369,26 @@ static gint compare_exec_id(gconstpointer a, gconstpointer b)
            (bb_a->exec_id < bb_b->exec_id);
 }
 
-static inline void try_output_to_bb_file(void) {
-    if (profiling_control.per_bb_vector_instr_count >= profiling_info.intervals) {
-        assert(profiling_control.bbv_file);
-        gzprintf(profiling_control.bbv_file, "T");
-        g_mutex_lock(&profiling_control.bbv_lock);
-        GList *bbv_list = g_list_sort(
-            g_hash_table_get_values(profiling_control.bbv), compare_exec_id);
+static void output_bbv_vector(void)
+{
+    assert(profiling_control.bbv_file);
+    gzprintf(profiling_control.bbv_file, "T");
+    g_mutex_lock(&profiling_control.bbv_lock);
+    GList *bbv_list = g_list_sort(
+        g_hash_table_get_values(profiling_control.bbv), compare_exec_id);
 
-        g_list_foreach(bbv_list, bbv_output, NULL);
-        g_list_free(bbv_list);
-        g_mutex_unlock(&profiling_control.bbv_lock);
-        gzprintf(profiling_control.bbv_file, "\n");
-        profiling_control.per_bb_vector_instr_count = 0;
+    g_list_foreach(bbv_list, bbv_output, NULL);
+    g_list_free(bbv_list);
+    g_mutex_unlock(&profiling_control.bbv_lock);
+    gzprintf(profiling_control.bbv_file, "\n");
+    profiling_control.per_bb_vector_instr_count = 0;
+}
+
+static void try_output_to_bb_file(void)
+{
+    if (profiling_control.per_bb_vector_instr_count >=
+        profiling_info.intervals) {
+        output_bbv_vector();
     }
 }
 
@@ -318,9 +400,7 @@ static void vcpu_tb_exec(unsigned int cpu_index, void *userdata) {
 
     BasicBlockExecCount_t *bb_cnt = userdata;
     /* Correct the preceding TB before a vector can be emitted and reset. */
-    if (profiling_control.start_profiling) {
-        try_output_to_bb_file();
-    }
+    try_output_to_bb_file();
 
     if (bb_cnt->exec_times == 0) {
         bb_cnt->exec_id = profiling_control.unique_exec_id++;
@@ -332,7 +412,6 @@ static void vcpu_tb_exec(unsigned int cpu_index, void *userdata) {
 
     // record global
     profiling_control.per_bb_vector_instr_count += bb_cnt->instrs;
-    profiling_control.execute_instr_counts += bb_cnt->instrs;
     profiling_control.profiling_instr_counts += bb_cnt->instrs;
 
 #ifndef NO_LOG
@@ -342,7 +421,7 @@ static void vcpu_tb_exec(unsigned int cpu_index, void *userdata) {
 
 }
 
-static inline void rollback_instr_counter(
+static void rollback_instr_counter(
     uint64_t unexecuted_insns, BasicBlockExecCount_t *original_bb_cnt,
     uint64_t first_pc, uint64_t second_pc) {
     if (original_bb_cnt == NULL) {
@@ -356,10 +435,8 @@ static inline void rollback_instr_counter(
     g_assert(unexecuted_insns <= profiling_control.profiling_instr_counts);
     g_assert(unexecuted_insns <=
              profiling_control.per_bb_vector_instr_count);
-    g_assert(unexecuted_insns <= profiling_control.execute_instr_counts);
     profiling_control.profiling_instr_counts -= unexecuted_insns;
     profiling_control.per_bb_vector_instr_count -= unexecuted_insns;
-    profiling_control.execute_instr_counts -= unexecuted_insns;
 #ifndef NO_LOG
     fprintf(stderr, "get mmio instr, sub instrs: %ld\n", unexecuted_insns);
     fflush(stderr);
@@ -373,8 +450,9 @@ static inline void rollback_instr_counter(
 }
 
 static void vcpu_tb_middle_exit_exec(unsigned int cpu_index, void *udata) {
-    if (cpu_index != 0)
+    if (cpu_index != 0) {
         return;
+    }
 
     uint64_t second_pc    = qemu_plugin_u64_get(current_block_end_pc, cpu_index);
     uint64_t current_block_first_pc = (uint64_t)udata;
@@ -460,30 +538,55 @@ static void vcpu_tb_trans(struct qemu_plugin_tb *tb, void *userdata) {
                                          QEMU_PLUGIN_CB_NO_REGS, (void *)bb_cnt);
 
     score_board_record_inject_before_insn_exec(tb, tb_instrs);
-
-    try_inject_nemu_trap_check(tb, tb_instrs);
 }
 
 
 static void profiling_exit(void *userdata) {
-    fprintf(stderr, "SimPoint profiling exit, total guest instructions = %ld, total profiling instrs = %ld\n",
-           profiling_control.execute_instr_counts, profiling_control.profiling_instr_counts);
+    if (profiling_control.state == PROFILING_ACTIVE) {
+        if (profiling_control.per_bb_vector_instr_count > 0) {
+            output_bbv_vector();
+        }
+
+        fprintf(stderr,
+                "SimPoint profiling exit, total guest instructions = %ld, "
+                "total profiling instrs = %ld\n",
+                profiling_control.profiling_instr_counts,
+                profiling_control.profiling_instr_counts);
+    } else {
+        fprintf(stderr,
+                "profilingv2: profiling never started; no BBV produced\n");
+    }
     fflush(stderr);
 
-    gzclose(profiling_control.bbv_file);
+    if (profiling_control.bbv_file) {
+        gzclose(profiling_control.bbv_file);
+        profiling_control.bbv_file = NULL;
+    }
     g_mutex_lock(&profiling_control.bbv_lock);
-    g_hash_table_destroy(profiling_control.bbv);
+    if (profiling_control.bbv) {
+        g_hash_table_destroy(profiling_control.bbv);
+        profiling_control.bbv = NULL;
+    }
     g_mutex_unlock(&profiling_control.bbv_lock);
     g_mutex_clear(&profiling_control.bbv_lock);
 
+    if (score_board) {
+        qemu_plugin_scoreboard_free(score_board);
+        score_board = NULL;
+    }
+
+    g_free(a0_registers);
+    a0_registers = NULL;
+    a0_register_count = 0;
 }
 
 QEMU_PLUGIN_EXPORT int qemu_plugin_install(qemu_plugin_id_t id,
                                            const qemu_info_t *info, int argc,
                                            char **argv) {
-    qemu_info = info;
+    plugin_id = id;
 
-    if (!qemu_info->system_emulation) {
+    if (!info->system_emulation ||
+        !g_str_has_prefix(info->target_name, "riscv")) {
         return -1;
     }
 
@@ -511,11 +614,13 @@ QEMU_PLUGIN_EXPORT int qemu_plugin_install(qemu_plugin_id_t id,
         }
     }
 
-    init_profiling_control(profiling_info.path.target_path, profiling_info.path.workload_path);
+    init_profiling_control();
 
-    init_score_board();
+    a0_register_count = info->system.max_vcpus;
+    a0_registers = g_new0(struct qemu_plugin_register *, a0_register_count);
 
-    qemu_plugin_register_vcpu_tb_trans_cb(id, vcpu_tb_trans, NULL);
+    qemu_plugin_register_vcpu_init_cb(id, vcpu_init, NULL);
+    qemu_plugin_register_vcpu_tb_trans_cb(id, waiting_vcpu_tb_trans, NULL);
 
     qemu_plugin_register_atexit_cb(id, profiling_exit, NULL);
 

--- a/target/riscv/tcg/insn_trans/trans_privileged.c.inc
+++ b/target/riscv/tcg/insn_trans/trans_privileged.c.inc
@@ -28,6 +28,7 @@
 static bool trans_nemu_trap(DisasContext *ctx, arg_nemu_trap *a)
 {
     gen_helper_nemu_trap(tcg_env, cpu_gpr[10]);
+    ctx->base.is_jmp = DISAS_TOO_MANY;
     return true;
 }
 


### PR DESCRIPTION
## Summary

- Detect profiling markers explicitly from the RISC-V `a0` register instead of relying on trap order.
- Reset pre-marker translations asynchronously and enable BBV instrumentation only after the BEGIN marker.
- End the marker TB at the trap instruction to provide an exact profiling boundary.
- Create BBV output only after profiling starts and flush the final partial vector when QEMU exits.

## Validation

- Built `qemu-system-riscv64` and `libprofilingv2.so`.
- Passed `git diff --check` and QEMU `checkpatch.pl`.
- Verified that a run without BEGIN produces no BBV and no success marker.
- Ran CoreMark successfully with 86 BBV rows.
- Verified that the BBV instruction sum (`170705449`) exactly matches the plugin total.

## Performance

In a matched single-run CoreMark A/B test using the same QEMU binary, firmware, CPU configuration, machine type, memory size, vCPU count, and BBV interval, deferring full profiling instrumentation until the explicit BEGIN marker reduced end-to-end wall time from 69.53s to 56.49s. This is an 18.75% reduction, corresponding to a 1.23x end-to-end speedup. Maximum RSS also decreased from 284916 KiB to 221464 KiB.
